### PR TITLE
Add license and update readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Codex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Dart Manager
+
+This project provides a simple web app for managing darts matches.
+
+## License
+
+This project is licensed under the terms of the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add MIT LICENSE
- document licensing in README

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_685881fdcaac8327b73cda358d214153

## Zusammenfassung von Sourcery

Fügt eine MIT-Lizenz zum Projekt hinzu und aktualisiert die README, um die Lizenzbedingungen zu dokumentieren.

Dokumentation:
- Dokumentiert die MIT-Lizenzierung des Projekts in der README

Sonstiges:
- Fügt eine LICENSE-Datei mit dem vollständigen MIT-Lizenztext hinzu

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an MIT license to the project and update the README to document the licensing terms

Documentation:
- Document the project’s MIT licensing in the README

Chores:
- Add a LICENSE file with the full MIT License text

</details>